### PR TITLE
change default chain to launch

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -28,7 +28,7 @@ parachains:
 # Config for first parachain
 - image: peaq_para_node:latest
   chain: # this could be a string like `dev` or a config object
-    base: dev # the chain to use
+    base: dev-local # the chain to use
     collators: # override collators
       - alice # this imply //Alice
       - bob # this imply //Bob


### PR DESCRIPTION
After this pr peaqnetwork/peaq-network-node/pull/101, default chain chainSpec to launch is 'dev-local' as 'dev' now fetches rawChainSpec for production peaq-dev network.