### PR TITLE
Update the fork scripts

### DIFF
--- a/scripts/config.parachain.krest.forked.v0.0.7.yml
+++ b/scripts/config.parachain.krest.forked.v0.0.7.yml
@@ -72,6 +72,7 @@ parachains:
     #   flags:
     #     - --dave
 # Config for xcm parachain
+# TODO After 102, the xcm remote rexecution work
 - image: peaq_para_node:latest
   chain: # this could be a string like `dev` or a config object
     base: dev-local # the chain to use

--- a/scripts/config.parachain.peaq-dev.docker.v0.0.101.yml
+++ b/scripts/config.parachain.peaq-dev.docker.v0.0.101.yml
@@ -75,6 +75,7 @@ parachains:
       flags:
         - --dave
 # Config for xcm parachain
+# TODO We should use 102 because 101 didn't support the XCM remote exeuction
 - image: peaq/parachain:peaq-dev-v0.0.101
   chain: # this could be a string like `dev` or a config object
     base: dev-local # the chain to use

--- a/scripts/config.parachain.peaq-dev.forked.v0.0.101.yml
+++ b/scripts/config.parachain.peaq-dev.forked.v0.0.101.yml
@@ -70,7 +70,8 @@ parachains:
     #   flags:
     #     - --dave
 # Config for xcm parachain
-- image: peaq/parachain:peaq-dev-v0.0.101
+# TODO We should use 102 because 101 didn't support the XCM remote exeuction
+- image: peaq_para_node:latest
   chain: # this could be a string like `dev` or a config object
     base: dev-local # the chain to use
     chainType: Development

--- a/scripts/config.parachain.peaq.docker.v0.0.102.yml
+++ b/scripts/config.parachain.peaq.docker.v0.0.102.yml
@@ -34,7 +34,7 @@ relaychain:
 # Parachain Configuration
 parachains:
 # Config for first parachain
-- image: peaq/parachain:peaq-v0.0.101
+- image: peaq/parachain:peaq-v0.0.102
   chain: # this could be a string like `dev` or a config object
     base: peaq-local # the chain to use
     chainType: Development
@@ -75,7 +75,8 @@ parachains:
       flags:
         - --dave
 # Config for xcm parachain
-- image: peaq/parachain:peaq-dev-v0.0.101
+# TODO We should use 103 because 102 didn't support the XCM remote exeuction
+- image: peaq/parachain:peaq-v0.0.102
   chain: # this could be a string like `dev` or a config object
     base: dev-local # the chain to use
     chainType: Development

--- a/scripts/config.parachain.peaq.forked.v0.0.102.yml
+++ b/scripts/config.parachain.peaq.forked.v0.0.102.yml
@@ -29,7 +29,7 @@ relaychain:
 # Parachain Configuration
 parachains:
 # Config for first parachain
-- image: peaq/parachain:peaq-v0.0.101
+- image: peaq/parachain:peaq-v0.0.102
   chain: # this could be a string like `dev` or a config object
     base: peaq-local # the chain to use
     chainType: Development
@@ -70,7 +70,8 @@ parachains:
     #   flags:
     #     - --dave
 # Config for xcm parachain
-- image: peaq/parachain:peaq-v0.0.101
+# TODO We should use 103 because 102 didn't support the XCM remote exeuction
+- image: peaq/parachain:peaq-v0.0.102
   chain: # this could be a string like `dev` or a config object
     base: dev-local # the chain to use
     chainType: Development

--- a/scripts/forked-peaq.sh
+++ b/scripts/forked-peaq.sh
@@ -1,8 +1,8 @@
-FORKED_CONFIG_FILE="scripts/config.parachain.peaq.forked.v0.0.101.yml" \
+FORKED_CONFIG_FILE="scripts/config.parachain.peaq.forked.v0.0.102.yml" \
 RPC_ENDPOINT="https://erpc-mpfn1.peaq.network" \
 DOCKER_COMPOSE_FOLDER="yoyo" \
 RELAY_CHAIN_CONFIG_FILE="rococo-local.json" \
-FORK_FOLDER="/home/jaypan/Work/peaq/fork-test/fork-binary/peaq-v0.0.101" \
+FORK_FOLDER="/home/jaypan/Work/peaq/fork-test/fork-binary/peaq-v0.0.102" \
 KEEP_COLLATOR="false" \
 KEEP_ASSET="true" \
 KEEP_PARACHAIN="false" \


### PR DESCRIPTION
1. Use the current version (102) on peaq
2. Add comments because we haven't packed the peaq-dev 102/ peaq 103 version