### PR TITLE
Better config

### DIFF
--- a/misc-configs/config.parachain.peaq-dev.100.yml
+++ b/misc-configs/config.parachain.peaq-dev.100.yml
@@ -124,3 +124,33 @@ parachains:
       port: 30443
       relaychainFlags: # additional CLI flags for relaychain part
         - --name=relaychain-9
+    - name: collator-10
+      wsPort: 10055
+      rpcPort: 20044
+      port: 30444
+      relaychainFlags: # additional CLI flags for relaychain part
+        - --name=relaychain-10
+    - name: collator-11
+      wsPort: 10056
+      rpcPort: 20045
+      port: 30445
+      relaychainFlags: # additional CLI flags for relaychain part
+        - --name=relaychain-11
+    - name: collator-12
+      wsPort: 10057
+      rpcPort: 20046
+      port: 30446
+      relaychainFlags: # additional CLI flags for relaychain part
+        - --name=relaychain-12
+    - name: collator-13
+      wsPort: 10058
+      rpcPort: 20047
+      port: 30447
+      relaychainFlags: # additional CLI flags for relaychain part
+        - --name=relaychain-13
+    - name: collator-14
+      wsPort: 10059
+      rpcPort: 20048
+      port: 30448
+      relaychainFlags: # additional CLI flags for relaychain part
+        - --name=relaychain-14


### PR DESCRIPTION
Implements 2 things we need when we need to do performance testing,

1. We need to deploy nodes in exponential order, i.e, 16, 32, 64...256. So updated config to generate 16 nodes.
2. We need to have more bootnodes, to do that, node's p2p port must be exposed through docker and through the VM. Therefore, updated project to map node's port to it's own port in docker, i.e, 30333:30333, 30334:30334
3. Nodes need to connect to alot more in/out nodes, introduced --in-peers and --out-peers argument.