### PR TITLE
Update Peaq parachain configs from v0.0.108 to v0.0.109

### DIFF
--- a/scripts/config.parachain.peaq.docker.nodes.v0.0.109.yml
+++ b/scripts/config.parachain.peaq.docker.nodes.v0.0.109.yml
@@ -1,7 +1,7 @@
 # Relaychain Configuration
 relaychain:
-  image: parity/polkadot:v1.8.0 # the docker image to use
-  chain: rococo-local # the chain to use
+  image: parity/polkadot:v1.13.0
+  chain: westend-local # the chain to use
   runtimeGenesisConfig: # additonal genesis override
     configuration:
       config:
@@ -10,32 +10,38 @@ relaychain:
         async_backing_params:
           max_candidate_depth: 3
           allowed_ancestry_len: 2
-        scheduling_lookahead: 2
   env: # environment variables for all relaychain nodes
     RUST_LOG: parachain::candidate-backing=trace,xcm=trace
   flags: # additional CLI flags for all relaychain nodes
     - --rpc-methods=unsafe
     - --no-hardware-benchmarks
     - --insecure-validator-i-know-what-i-do
-    # - --unsafe-force-node-key-generation
+    - --unsafe-force-node-key-generation
   nodes: # nodes config
     - name: alice # the node name and session key, this imply `--alice`
-      wsPort: 9944 # default ws port number is `9944 + global_node_index`
-      rpcPort: 9933 # default rpc port number is `9933 + global_node_index`
-      port: 30333 # default libp2p port number is `30333 + global_node_index`
+      wsPort: 10044 # default ws port number is `9944 + global_node_index`
+      port: 40333 # default libp2p port number is `30333 + global_node_index`
     - name: bob
+      wsPort: 10045
+      port: 40334
     - name: charlie
+      wsPort: 10046
+      port: 40335
 
 # Parachain Configuration
 parachains:
 # Config for first parachain
-- image: peaq/parachain:peaq-v0.0.108
+- image: peaq/parachain:peaq-v0.0.109
   chain: # this could be a string like `dev` or a config object
     base: peaq-local # the chain to use
     chainType: Development
     collators: # override collators
+      - alice
+      - bob
+      - charlie
+      - dave
+      - eve
       - ferdie
-      # - dave
     sudo: alice # override sudo key to //Alice
     runtimeGenesisConfig: # additonal genesis override
       balances:
@@ -59,16 +65,36 @@ parachains:
     RUST_LOG: sc_basic_authorship=trace,xcm=trace
   volumePath: /chain-data # The path to mount volume and base path, default to /data
   nodes: # nodes config
-    - wsPort: 10044
-      port: 40336
+    - wsPort: 9944
+      port: 30336
       flags: # additional CLI flags for this node
-        - --ferdie
-    # - wsPort: 10045
-    #   port: 40337
+        - --alice
+    - wsPort: 9945
+      port: 30337
+      flags:
+        - --bob
+    - wsPort: 9946
+      port: 30338
+      flags:
+        - --charlie
+    - wsPort: 9947
+      port: 30339
+      flags:
+        - --dave
+    # - wsPort: 9948
+    #   port: 30340
     #   flags:
-    #     - --dave
+    #     - --eve
+    # - wsPort: 9949
+    #   port: 30341
+    #   flags:
+    #     - --ferdie
+    # - wsPort: 9950
+    #   port: 30342
+    # - wsPort: 9951
+    #   port: 30343
 # Config for xcm parachain
-- image: peaq/parachain:peaq-v0.0.108
+- image: peaq/parachain:peaq-v0.0.109
   chain: # this could be a string like `dev` or a config object
     base: dev-local # the chain to use
     chainType: Development
@@ -101,6 +127,7 @@ parachains:
   nodes: # nodes config
     - name: ferdie
       wsPort: 10144
+      rpcPort: 10233
       port: 30533
       flags: # additional CLI flags for this node
         - --ferdie

--- a/scripts/config.parachain.peaq.docker.v0.0.109.yml
+++ b/scripts/config.parachain.peaq.docker.v0.0.109.yml
@@ -20,28 +20,27 @@ relaychain:
   nodes: # nodes config
     - name: alice # the node name and session key, this imply `--alice`
       wsPort: 10044 # default ws port number is `9944 + global_node_index`
+      rpcPort: 10033 # default rpc port number is `9933 + global_node_index`
       port: 40333 # default libp2p port number is `30333 + global_node_index`
     - name: bob
       wsPort: 10045
+      rpcPort: 10034
       port: 40334
     - name: charlie
       wsPort: 10046
+      rpcPort: 10035
       port: 40335
 
 # Parachain Configuration
 parachains:
 # Config for first parachain
-- image: peaq/parachain:peaq-v0.0.108
+- image: peaq/parachain:peaq-v0.0.109
   chain: # this could be a string like `dev` or a config object
     base: peaq-local # the chain to use
     chainType: Development
     collators: # override collators
-      - alice
-      - bob
-      - charlie
-      - dave
-      - eve
       - ferdie
+      - dave
     sudo: alice # override sudo key to //Alice
     runtimeGenesisConfig: # additonal genesis override
       balances:
@@ -68,33 +67,13 @@ parachains:
     - wsPort: 9944
       port: 30336
       flags: # additional CLI flags for this node
-        - --alice
+        - --ferdie
     - wsPort: 9945
       port: 30337
       flags:
-        - --bob
-    - wsPort: 9946
-      port: 30338
-      flags:
-        - --charlie
-    - wsPort: 9947
-      port: 30339
-      flags:
         - --dave
-    # - wsPort: 9948
-    #   port: 30340
-    #   flags:
-    #     - --eve
-    # - wsPort: 9949
-    #   port: 30341
-    #   flags:
-    #     - --ferdie
-    # - wsPort: 9950
-    #   port: 30342
-    # - wsPort: 9951
-    #   port: 30343
 # Config for xcm parachain
-- image: peaq/parachain:peaq-v0.0.108
+- image: peaq/parachain:peaq-v0.0.109
   chain: # this could be a string like `dev` or a config object
     base: dev-local # the chain to use
     chainType: Development
@@ -127,7 +106,6 @@ parachains:
   nodes: # nodes config
     - name: ferdie
       wsPort: 10144
-      rpcPort: 10233
       port: 30533
       flags: # additional CLI flags for this node
         - --ferdie

--- a/scripts/config.parachain.peaq.forked.v0.0.109.yml
+++ b/scripts/config.parachain.peaq.forked.v0.0.109.yml
@@ -1,7 +1,7 @@
 # Relaychain Configuration
 relaychain:
-  image: parity/polkadot:v1.13.0
-  chain: westend-local # the chain to use
+  image: parity/polkadot:v1.8.0 # the docker image to use
+  chain: rococo-local # the chain to use
   runtimeGenesisConfig: # additonal genesis override
     configuration:
       config:
@@ -10,37 +10,32 @@ relaychain:
         async_backing_params:
           max_candidate_depth: 3
           allowed_ancestry_len: 2
+        scheduling_lookahead: 2
   env: # environment variables for all relaychain nodes
     RUST_LOG: parachain::candidate-backing=trace,xcm=trace
   flags: # additional CLI flags for all relaychain nodes
     - --rpc-methods=unsafe
     - --no-hardware-benchmarks
     - --insecure-validator-i-know-what-i-do
-    - --unsafe-force-node-key-generation
+    # - --unsafe-force-node-key-generation
   nodes: # nodes config
     - name: alice # the node name and session key, this imply `--alice`
-      wsPort: 10044 # default ws port number is `9944 + global_node_index`
-      rpcPort: 10033 # default rpc port number is `9933 + global_node_index`
-      port: 40333 # default libp2p port number is `30333 + global_node_index`
+      wsPort: 9944 # default ws port number is `9944 + global_node_index`
+      rpcPort: 9933 # default rpc port number is `9933 + global_node_index`
+      port: 30333 # default libp2p port number is `30333 + global_node_index`
     - name: bob
-      wsPort: 10045
-      rpcPort: 10034
-      port: 40334
     - name: charlie
-      wsPort: 10046
-      rpcPort: 10035
-      port: 40335
 
 # Parachain Configuration
 parachains:
 # Config for first parachain
-- image: peaq/parachain:peaq-v0.0.108
+- image: peaq/parachain:peaq-v0.0.109
   chain: # this could be a string like `dev` or a config object
     base: peaq-local # the chain to use
     chainType: Development
     collators: # override collators
       - ferdie
-      - dave
+      # - dave
     sudo: alice # override sudo key to //Alice
     runtimeGenesisConfig: # additonal genesis override
       balances:
@@ -64,16 +59,16 @@ parachains:
     RUST_LOG: sc_basic_authorship=trace,xcm=trace
   volumePath: /chain-data # The path to mount volume and base path, default to /data
   nodes: # nodes config
-    - wsPort: 9944
-      port: 30336
+    - wsPort: 10044
+      port: 40336
       flags: # additional CLI flags for this node
         - --ferdie
-    - wsPort: 9945
-      port: 30337
-      flags:
-        - --dave
+    # - wsPort: 10045
+    #   port: 40337
+    #   flags:
+    #     - --dave
 # Config for xcm parachain
-- image: peaq/parachain:peaq-v0.0.108
+- image: peaq/parachain:peaq-v0.0.109
   chain: # this could be a string like `dev` or a config object
     base: dev-local # the chain to use
     chainType: Development

--- a/scripts/forked-peaq.sh
+++ b/scripts/forked-peaq.sh
@@ -1,8 +1,8 @@
-FORKED_CONFIG_FILE="scripts/config.parachain.peaq.forked.v0.0.108.yml" \
+FORKED_CONFIG_FILE="scripts/config.parachain.peaq.forked.v0.0.109.yml" \
 RPC_ENDPOINT="wss://mpfn1.peaq.network" \
 DOCKER_COMPOSE_FOLDER="yoyo" \
 RELAY_CHAIN_CONFIG_FILE="rococo-local.json" \
-FORK_FOLDER="/home/jaypan/Work/peaq/fork-test/fork-binary/peaq-v0.0.108" \
+FORK_FOLDER="/home/jaypan/Work/peaq/fork-test/fork-binary/peaq-v0.0.109" \
 KEEP_COLLATOR="false" \
 KEEP_ASSET="true" \
 KEEP_PARACHAIN="false" \


### PR DESCRIPTION
- Updated Docker image versions in all Peaq config files
- Renamed config files to reflect new version (108 -> 109)
- Updated binary paths in forked-peaq.sh script